### PR TITLE
add component: clamp-text; alpha release

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -45,6 +45,12 @@ export let genRouter = {
     path: () => `/loading-indicator`,
     go: () => switchPath(`/loading-indicator`),
   },
+  clampText: {
+    name: "clamp-text",
+    raw: "clamp-text",
+    path: () => `/clamp-text`,
+    go: () => switchPath(`/clamp-text`),
+  },
   $: {
     name: "home",
     raw: "",
@@ -59,6 +65,7 @@ export type GenRouterTypeMain =
   | GenRouterTypeTree["tabs"]
   | GenRouterTypeTree["todo"]
   | GenRouterTypeTree["loadingIndicator"]
+  | GenRouterTypeTree["clampText"]
   | GenRouterTypeTree["$"];
 
 export interface GenRouterTypeTree {
@@ -88,6 +95,12 @@ export interface GenRouterTypeTree {
   };
   loadingIndicator: {
     name: "loading-indicator";
+    params: {};
+    query: {};
+    next: null;
+  };
+  clampText: {
+    name: "clamp-text";
     params: {};
     query: {};
     next: null;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -6,5 +6,6 @@ export const routerRules: IRouteRule[] = [
   { path: "tabs" },
   { path: "todo" },
   { path: "loading-indicator" },
+  { path: "clamp-text" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -9,6 +9,7 @@ import DemoButtons from "./demo/buttons";
 import DemoTodo from "./demo/todo";
 import DemoTabs from "./demo/tabs";
 import DemoLoadingIndicator from "./demo/loading-indicator";
+import DemoClampText from "./demo/clamp-text";
 
 let items: ISidebarEntry[] = [
   {
@@ -27,6 +28,10 @@ let items: ISidebarEntry[] = [
     title: "Loading indicator",
     path: genRouter.loadingIndicator.name,
   },
+  {
+    title: "Clamp text",
+    path: genRouter.clampText.name,
+  },
 ];
 
 const renderChildPage = (routerTree: GenRouterTypeMain) => {
@@ -40,6 +45,8 @@ const renderChildPage = (routerTree: GenRouterTypeMain) => {
         return <DemoTabs />;
       case "loading-indicator":
         return <DemoLoadingIndicator />;
+      case "clamp-text":
+        return <DemoClampText />;
       default:
         return <HashRedirect to={genRouter.buttons.name} noDelay></HashRedirect>;
     }

--- a/example/pages/demo/clamp-text.tsx
+++ b/example/pages/demo/clamp-text.tsx
@@ -1,0 +1,67 @@
+import React, { FC } from "react";
+import { css } from "emotion";
+import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
+import ClampText from "../../../src/clamp-text";
+import { Space } from "@jimengio/flex-styles";
+
+let DemoClampText: FC<{}> = React.memo((props) => {
+  /** Plugins */
+  /** Methods */
+  /** Effects */
+  /** Renderers */
+  return (
+    <div>
+      <DocDemo title={"Single line"}>
+        <DocBlock content={contentInline} />
+        <DocSnippet code={codeInline} />
+        <div className={styleNarrow}>
+          <ClampText text="As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment." />
+        </div>
+      </DocDemo>
+
+      <DocDemo title={"multiple lines"}>
+        <DocBlock content={contentMultilpeLines} />
+        <DocSnippet code={code2Lines} />
+        <div className={styleNarrow}>
+          <ClampText
+            lines={2}
+            text="As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment."
+          />
+
+          <Space height={16} />
+        </div>
+
+        <Space height={16} />
+
+        <DocSnippet code={code4Lines} />
+        <div className={styleNarrow}>
+          <ClampText
+            lines={4}
+            text="As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment."
+          />
+        </div>
+      </DocDemo>
+    </div>
+  );
+});
+
+export default DemoClampText;
+
+let styleNarrow = css`
+  width: 200px;
+  border: 1px solid #eee;
+`;
+
+let contentInline = `
+单行的文字用省略号隐藏超出宽度的部分. 注意这时用的标签是 div.
+`;
+
+let contentMultilpeLines = `
+多行的文字省略通过私有属性 \`-webkit-line-clamp\` 来实现. 某些浏览器会存在兼容性问题. 具体具体参考 https://css-tricks.com/almanac/properties/l/line-clamp/ .
+`;
+
+let codeInline = `<ClampText text={text} />`;
+
+let code2Lines = `<ClampText lines={2} text={text} />`;
+
+let code4Lines = `<ClampText lines={4} text={text} />`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.4",
+  "version": "0.0.5-a1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.5-a1",
+  "version": "0.0.5-a2",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from "react";
+import { css } from "emotion";
+
+let ClampText: FC<{
+  /** defaults to 1 */
+  lines?: number;
+  text: string;
+}> = React.memo((props) => {
+  let lines = props.lines || 1;
+  /** Plugins */
+  /** Methods */
+  /** Effects */
+  /** Renderers */
+
+  if (lines === 1) {
+    return <div className={styleSingleLine}>{props.text}</div>;
+  }
+
+  return (
+    <div
+      className={styleClampText}
+      style={{
+        WebkitLineClamp: lines,
+      }}
+    >
+      {props.text}
+    </div>
+  );
+});
+
+export default ClampText;
+
+// based on https://css-tricks.com/almanac/properties/l/line-clamp/
+let styleClampText = css`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+let styleSingleLine = css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -35,6 +35,7 @@ let styleClampText = css`
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 let styleSingleLine = css`

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { default as UnderlineTabs } from "./underline-tabs";
 export { default as TodoFeature } from "./todo-feature";
 export { default as LoadingIndicator } from "./loading-indicator";
 export { default as LoadingArea } from "./loading-indicator";
+export { default as ClampText } from "./clamp-text";


### PR DESCRIPTION
Previews http://fe.jimu.io/jimo-basics/#/clamp-text .

用到了 Webkit 私有属性, 目前 Chrome, Safari 11, Firefox 72 看起来正常. IE11 不确定但用了 text-overflow 可能有效果. 如果后面需要完整的支持, 只能探测浏览器使用 https://github.com/josephschmitt/Clamp.js 进行 DOM 操作来实现效果了.
