### PR TITLE
try tooltip for truncated text; alpha release

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -51,6 +51,12 @@ export let genRouter = {
     path: () => `/clamp-text`,
     go: () => switchPath(`/clamp-text`),
   },
+  textTooltip: {
+    name: "text-tooltip",
+    raw: "text-tooltip",
+    path: () => `/text-tooltip`,
+    go: () => switchPath(`/text-tooltip`),
+  },
   $: {
     name: "home",
     raw: "",
@@ -66,6 +72,7 @@ export type GenRouterTypeMain =
   | GenRouterTypeTree["todo"]
   | GenRouterTypeTree["loadingIndicator"]
   | GenRouterTypeTree["clampText"]
+  | GenRouterTypeTree["textTooltip"]
   | GenRouterTypeTree["$"];
 
 export interface GenRouterTypeTree {
@@ -101,6 +108,12 @@ export interface GenRouterTypeTree {
   };
   clampText: {
     name: "clamp-text";
+    params: {};
+    query: {};
+    next: null;
+  };
+  textTooltip: {
+    name: "text-tooltip";
     params: {};
     query: {};
     next: null;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -7,5 +7,6 @@ export const routerRules: IRouteRule[] = [
   { path: "todo" },
   { path: "loading-indicator" },
   { path: "clamp-text" },
+  { path: "text-tooltip" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -85,7 +85,9 @@ let Container: FC<{
 
 export default Container;
 
-const styleContainer = css``;
+const styleContainer = css`
+  overflow: auto;
+`;
 
 let styleBody = css`
   padding: 16px;

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -10,6 +10,7 @@ import DemoTodo from "./demo/todo";
 import DemoTabs from "./demo/tabs";
 import DemoLoadingIndicator from "./demo/loading-indicator";
 import DemoClampText from "./demo/clamp-text";
+import DemoTextTooltip from "./demo/text-tooltip";
 
 let items: ISidebarEntry[] = [
   {
@@ -32,6 +33,10 @@ let items: ISidebarEntry[] = [
     title: "Clamp text",
     path: genRouter.clampText.name,
   },
+  {
+    title: "Text tooltip",
+    path: genRouter.textTooltip.name,
+  },
 ];
 
 const renderChildPage = (routerTree: GenRouterTypeMain) => {
@@ -47,6 +52,8 @@ const renderChildPage = (routerTree: GenRouterTypeMain) => {
         return <DemoLoadingIndicator />;
       case "clamp-text":
         return <DemoClampText />;
+      case "text-tooltip":
+        return <DemoTextTooltip />;
       default:
         return <HashRedirect to={genRouter.buttons.name} noDelay></HashRedirect>;
     }

--- a/example/pages/demo/clamp-text.tsx
+++ b/example/pages/demo/clamp-text.tsx
@@ -4,6 +4,9 @@ import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
 import ClampText from "../../../src/clamp-text";
 import { Space } from "@jimengio/flex-styles";
 
+let text =
+  "As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment.";
+
 let DemoClampText: FC<{}> = React.memo((props) => {
   /** Plugins */
   /** Methods */
@@ -15,7 +18,7 @@ let DemoClampText: FC<{}> = React.memo((props) => {
         <DocBlock content={contentInline} />
         <DocSnippet code={codeInline} />
         <div className={styleNarrow}>
-          <ClampText text="As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment." />
+          <ClampText text={text} />
         </div>
       </DocDemo>
 
@@ -23,10 +26,7 @@ let DemoClampText: FC<{}> = React.memo((props) => {
         <DocBlock content={contentMultilpeLines} />
         <DocSnippet code={code2Lines} />
         <div className={styleNarrow}>
-          <ClampText
-            lines={2}
-            text="As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment."
-          />
+          <ClampText lines={2} text={text} />
 
           <Space height={16} />
         </div>
@@ -35,9 +35,31 @@ let DemoClampText: FC<{}> = React.memo((props) => {
 
         <DocSnippet code={code4Lines} />
         <div className={styleNarrow}>
+          <ClampText lines={4} text={text} />
+        </div>
+      </DocDemo>
+
+      <DocDemo title={"Tooltips"}>
+        <DocBlock content={contentTooltip} />
+        <DocSnippet code={codeTooltip} />
+        <div className={styleNarrow}>
+          <ClampText text={text} addTooltip />
+          <Space height={40} />
+          <ClampText text={text} lines={2} addTooltip />
+          <Space height={40} />
+          <ClampText text={"短就不显示"} addTooltip />
+        </div>
+        <Space height={40} />
+
+        <DocBlock content={contentTooltipState} />
+        <DocSnippet code={codeTooltipState} />
+        <div className={styleNarrow}>
           <ClampText
-            lines={4}
-            text="As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment."
+            text={text}
+            lines={2}
+            onTooltipStateChange={(visible) => {
+              console.log("Tooltip visible", visible);
+            }}
           />
         </div>
       </DocDemo>
@@ -65,3 +87,21 @@ let codeInline = `<ClampText text={text} />`;
 let code2Lines = `<ClampText lines={2} text={text} />`;
 
 let code4Lines = `<ClampText lines={4} text={text} />`;
+
+let contentTooltip = `有内容被省略的位置, 可以通过 \`addTooltip\` 属性控制显示完整内容`;
+
+let codeTooltip = `<ClampText text={text} addTooltip />`;
+
+let codeTooltipState = `
+<ClampText
+  text={text}
+  lines={2}
+  onTooltipStateChange={(visible) => {
+    console.log("Tooltip visible", visible);
+  }}
+/>
+`;
+
+let contentTooltipState = `
+通过 \`onTooltipStateChange\` 可以获取是否需要显示 Tooltip 这个状态.
+`;

--- a/example/pages/demo/text-tooltip.tsx
+++ b/example/pages/demo/text-tooltip.tsx
@@ -7,38 +7,13 @@ import { Space } from "@jimengio/flex-styles";
 let text =
   "As of right now, it's browser support. Line clamps are part of the CSS Overflow Module Level 3 which is currently in Editor's Draft and totally unsupported at the moment. 上海积梦智能科技有限公司， s为亟待升级改革的离散型制造业提供数字化工厂解决方案。积梦智能通过互联网和物联网技术，帮助企业快速建设自己的数字工厂，实现生产运营的可视化，驱动管理实时决策，助力企业提升运营效率，降低运营成本，从而获取更快的市场响应速度。 ";
 
-let DemoClampText: FC<{}> = React.memo((props) => {
+let DemoTextTooltip: FC<{}> = React.memo((props) => {
   /** Plugins */
   /** Methods */
   /** Effects */
   /** Renderers */
   return (
     <div>
-      <DocDemo title={"Single line"}>
-        <DocBlock content={contentInline} />
-        <DocSnippet code={codeInline} />
-        <div className={styleNarrow}>
-          <ClampText text={text} />
-        </div>
-      </DocDemo>
-
-      <DocDemo title={"multiple lines"}>
-        <DocBlock content={contentMultilpeLines} />
-        <DocSnippet code={code2Lines} />
-        <div className={styleNarrow}>
-          <ClampText lines={2} text={text} />
-
-          <Space height={16} />
-        </div>
-
-        <Space height={16} />
-
-        <DocSnippet code={code4Lines} />
-        <div className={styleNarrow}>
-          <ClampText lines={4} text={text} />
-        </div>
-      </DocDemo>
-
       <DocDemo title={"Tooltips"}>
         <DocBlock content={contentTooltip} />
         <DocSnippet code={codeTooltip} />
@@ -67,26 +42,12 @@ let DemoClampText: FC<{}> = React.memo((props) => {
   );
 });
 
-export default DemoClampText;
+export default DemoTextTooltip;
 
 let styleNarrow = css`
   width: 200px;
   border: 1px solid #eee;
 `;
-
-let contentInline = `
-单行的文字用省略号隐藏超出宽度的部分. 注意这时用的标签是 div.
-`;
-
-let contentMultilpeLines = `
-多行的文字省略通过私有属性 \`-webkit-line-clamp\` 来实现. 某些浏览器会存在兼容性问题. 具体具体参考 https://css-tricks.com/almanac/properties/l/line-clamp/ .
-`;
-
-let codeInline = `<ClampText text={text} />`;
-
-let code2Lines = `<ClampText lines={2} text={text} />`;
-
-let code4Lines = `<ClampText lines={4} text={text} />`;
 
 let contentTooltip = `有内容被省略的位置, 可以通过 \`addTooltip\` 属性控制显示完整内容`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.8-a4",
+  "version": "0.0.8-a5",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.8-a1",
+  "version": "0.0.8-a2",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.8-a3",
+  "version": "0.0.8-a4",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.8-a2",
+  "version": "0.0.8-a3",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.8-a5",
+  "version": "0.0.8-a7",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.7",
+  "version": "0.0.8-a1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState, useRef } from "react";
 import { css, cx } from "emotion";
+import BasicTooltip from "./tooltip";
 
 let ClampText: FC<{
   /** defaults to 1 */
@@ -51,19 +52,7 @@ let ClampText: FC<{
   /** Renderers */
 
   let renderTooltip = () => {
-    if (props.addTooltip && showToopTip) {
-      return (
-        <div
-          className={cx(styleTooptip, props.tooltipClassName)}
-          style={{
-            left: pointer.x,
-            bottom: window.innerHeight - pointer.y + 6,
-          }}
-        >
-          {props.text}
-        </div>
-      );
-    }
+    return <BasicTooltip pointer={pointer} visible={props.addTooltip && showToopTip} className={props.tooltipClassName} text={props.text} />;
   };
 
   if (lines === 1) {
@@ -124,36 +113,4 @@ let styleSingleLine = css`
 
   max-width: 100%;
   word-break: break-word;
-`;
-
-let styleTooptip = css`
-  position: fixed;
-  transform: translate(-50%, 0);
-  background-color: hsl(0, 0%, 0%);
-  color: white;
-  padding: 4px 6px;
-  border-radius: 3px;
-  font-size: 13px;
-  max-width: 320px;
-
-  white-space: normal;
-
-  :before {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    display: block;
-    width: 20px;
-    height: 8px;
-    margin: auto;
-    content: "";
-    pointer-events: auto;
-    border-top: 8px solid black;
-    border-bottom: 0px solid transparent;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    box-sizing: border-box;
-  }
 `;

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState, useRef } from "react";
 import { css, cx } from "emotion";
 
 let ClampText: FC<{
@@ -6,25 +6,100 @@ let ClampText: FC<{
   lines?: number;
   text: string;
   className?: string;
+  tooltipClassName?: string;
+  addTooltip?: boolean;
+  onTooltipStateChange?: (visible?: boolean) => void;
 }> = React.memo((props) => {
+  let elRef = useRef<HTMLDivElement>();
+
+  let [showToopTip, setShowTooltip] = useState(false);
+  let [pointer, setPointer] = useState({ x: 0, y: 0 });
+
   let lines = props.lines || 1;
+
   /** Plugins */
   /** Methods */
+
+  let detectTruncated = () => {
+    let el = elRef.current;
+
+    let truncated = el.offsetHeight < el.scrollHeight || el.offsetWidth < el.scrollWidth;
+
+    if (props.addTooltip || props.onTooltipStateChange != null) {
+      let rect = el.getBoundingClientRect() as DOMRect;
+
+      setShowTooltip(truncated);
+      setPointer({
+        x: rect.left + el.offsetWidth / 2,
+        y: rect.top,
+      });
+
+      if (props.onTooltipStateChange != null) {
+        props.onTooltipStateChange(truncated);
+      }
+    }
+  };
+
+  let handleLeave = () => {
+    setShowTooltip(false);
+    if (props.onTooltipStateChange != null && showToopTip) {
+      props.onTooltipStateChange(false);
+    }
+  };
+
   /** Effects */
   /** Renderers */
 
+  let renderTooltip = () => {
+    if (props.addTooltip && showToopTip) {
+      return (
+        <div
+          className={cx(styleTooptip, props.tooltipClassName)}
+          style={{
+            left: pointer.x,
+            bottom: window.innerHeight - pointer.y + 6,
+          }}
+        >
+          {props.text}
+        </div>
+      );
+    }
+  };
+
   if (lines === 1) {
-    return <div className={cx(styleSingleLine, props.className)}>{props.text}</div>;
+    return (
+      <div
+        className={cx(styleSingleLine, props.className)}
+        ref={elRef}
+        onMouseEnter={() => {
+          detectTruncated();
+        }}
+        onMouseLeave={() => {
+          handleLeave();
+        }}
+      >
+        {props.text}
+        {renderTooltip()}
+      </div>
+    );
   }
 
   return (
     <div
       className={styleClampText}
+      ref={elRef}
       style={{
         WebkitLineClamp: lines,
       }}
+      onMouseEnter={() => {
+        detectTruncated();
+      }}
+      onMouseLeave={() => {
+        handleLeave();
+      }}
     >
       {props.text}
+      {renderTooltip()}
     </div>
   );
 });
@@ -49,4 +124,36 @@ let styleSingleLine = css`
 
   max-width: 100%;
   word-break: break-word;
+`;
+
+let styleTooptip = css`
+  position: fixed;
+  transform: translate(-50%, 0);
+  background-color: hsl(0, 0%, 0%);
+  color: white;
+  padding: 4px 6px;
+  border-radius: 3px;
+  font-size: 13px;
+  max-width: 320px;
+
+  white-space: normal;
+
+  :before {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    width: 20px;
+    height: 8px;
+    margin: auto;
+    content: "";
+    pointer-events: auto;
+    border-top: 8px solid black;
+    border-bottom: 0px solid transparent;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    box-sizing: border-box;
+  }
 `;

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -52,7 +52,10 @@ let ClampText: FC<{
   /** Renderers */
 
   let renderTooltip = () => {
-    return <BasicTooltip pointer={pointer} visible={props.addTooltip && showToopTip} className={props.tooltipClassName} text={props.text} />;
+    if (!props.addTooltip) {
+      return null;
+    }
+    return <BasicTooltip pointer={pointer} visible={showToopTip} className={props.tooltipClassName} text={props.text} />;
   };
 
   if (lines === 1) {

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from "react";
+import React, { FC, useRef, useEffect } from "react";
+import ReactDOM from "react-dom";
 import { css, cx } from "emotion";
 import { CSSTransition } from "react-transition-group";
 
@@ -11,11 +12,26 @@ let BasicTooltip: FC<{
   text: string;
   className?: string;
 }> = React.memo((props) => {
+  let containerRef = useRef<HTMLDivElement>();
+
   /** Plugins */
   /** Methods */
   /** Effects */
+
+  if (containerRef.current == null) {
+    let el = document.createElement("div");
+    containerRef.current = el;
+  }
+
+  useEffect(() => {
+    document.body.appendChild(containerRef.current);
+    return () => {
+      containerRef.current.remove();
+    };
+  }, []);
+
   /** Renderers */
-  return (
+  return ReactDOM.createPortal(
     <span className={styleTooltipContainer}>
       <CSSTransition in={props.visible} timeout={transitionDuration} classNames="fade-in-out" unmountOnExit>
         <div
@@ -28,7 +44,8 @@ let BasicTooltip: FC<{
           {props.text}
         </div>
       </CSSTransition>
-    </span>
+    </span>,
+    containerRef.current
   );
 });
 

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -3,6 +3,7 @@ import { css, cx } from "emotion";
 import { CSSTransition } from "react-transition-group";
 
 let transitionDuration = 120;
+let tipColor = "rgb(239,239,239)";
 
 let BasicTooltip: FC<{
   visible: boolean;
@@ -40,8 +41,8 @@ let styleTooptip = css`
   transform: translate(-50%, 0) scale(1);
   transition-property: opacity transform;
   transform-origin: 50% calc(100% + 6px);
-  background-color: #323232;
-  color: white;
+  background-color: ${tipColor};
+  color: #323232;
   padding: 5px 8px;
   border-radius: 2px;
   font-size: 13px;
@@ -63,7 +64,7 @@ let styleTooptip = css`
     margin: auto;
     content: "";
     pointer-events: auto;
-    border-top: 8px solid #323232;
+    border-top: 8px solid ${tipColor};
     border-bottom: 0px solid transparent;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -20,6 +20,7 @@ let BasicTooltip: FC<{
 
   if (containerRef.current == null) {
     let el = document.createElement("div");
+    el.className = styleTooltipContainer;
     containerRef.current = el;
   }
 
@@ -32,19 +33,17 @@ let BasicTooltip: FC<{
 
   /** Renderers */
   return ReactDOM.createPortal(
-    <span className={styleTooltipContainer}>
-      <CSSTransition in={props.visible} timeout={transitionDuration} classNames="fade-in-out" unmountOnExit>
-        <div
-          className={cx(styleTooptip, props.className)}
-          style={{
-            left: props.pointer.x,
-            bottom: window.innerHeight - props.pointer.y + 6,
-          }}
-        >
-          {props.text}
-        </div>
-      </CSSTransition>
-    </span>,
+    <CSSTransition in={props.visible} timeout={transitionDuration} classNames="fade-in-out" unmountOnExit>
+      <div
+        className={cx(styleTooptip, props.className)}
+        style={{
+          left: props.pointer.x,
+          bottom: window.innerHeight - props.pointer.y + 6,
+        }}
+      >
+        {props.text}
+      </div>
+    </CSSTransition>,
     containerRef.current
   );
 });
@@ -68,6 +67,7 @@ let styleTooptip = css`
   line-height: 22px;
 
   white-space: normal;
+  word-break: break-word;
 
   :before {
     position: absolute;
@@ -100,7 +100,8 @@ let styleTooptip = css`
 `;
 
 let styleTooltipContainer = css`
-  z-index: 900;
+  z-index: 1200; /* display above modals */
+  position: absolute;
 
   .fade-in-out-enter {
     opacity: 0.3;

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -35,14 +35,19 @@ export default BasicTooltip;
 
 let styleTooptip = css`
   position: fixed;
-  transform: translate(-50%, 0);
+  animation-timing-function: ease-in-out;
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+  transition-property: opacity transform;
   transform-origin: 50% calc(100% + 6px);
-  background-color: hsl(0, 0%, 0%);
+  background-color: #323232;
   color: white;
-  padding: 4px 6px;
-  border-radius: 3px;
+  padding: 5px 8px;
+  border-radius: 2px;
   font-size: 13px;
-  max-width: 320px;
+  max-width: 280px;
+  font-size: 14px;
+  line-height: 22px;
 
   white-space: normal;
 
@@ -58,11 +63,21 @@ let styleTooptip = css`
     margin: auto;
     content: "";
     pointer-events: auto;
-    border-top: 8px solid black;
+    border-top: 8px solid #323232;
     border-bottom: 0px solid transparent;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
     box-sizing: border-box;
+  }
+
+  :after {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    height: 8px;
+    width: 100%;
+    content: "";
+    background-color: transparent;
   }
 `;
 
@@ -76,7 +91,6 @@ let styleTooltipContainer = css`
   .fade-in-out-enter-active {
     opacity: 1;
     transform: translate(-50%, 0) scale(1);
-    transition-property: opacity transform;
     transition-duration: ${transitionDuration}ms;
   }
   .fade-in-out-exit {
@@ -86,7 +100,6 @@ let styleTooltipContainer = css`
   .fade-in-out-exit-active {
     opacity: 0.3;
     transform: translate(-50%, 0) scale(0.94);
-    transition-property: opacity transform;
     transition-duration: ${transitionDuration}ms;
   }
 `;

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -1,0 +1,92 @@
+import React, { FC } from "react";
+import { css, cx } from "emotion";
+import { CSSTransition } from "react-transition-group";
+
+let transitionDuration = 120;
+
+let BasicTooltip: FC<{
+  visible: boolean;
+  pointer: { x: number; y: number };
+  text: string;
+  className?: string;
+}> = React.memo((props) => {
+  /** Plugins */
+  /** Methods */
+  /** Effects */
+  /** Renderers */
+  return (
+    <span className={styleTooltipContainer}>
+      <CSSTransition in={props.visible} timeout={transitionDuration} classNames="fade-in-out" unmountOnExit>
+        <div
+          className={cx(styleTooptip, props.className)}
+          style={{
+            left: props.pointer.x,
+            bottom: window.innerHeight - props.pointer.y + 6,
+          }}
+        >
+          {props.text}
+        </div>
+      </CSSTransition>
+    </span>
+  );
+});
+
+export default BasicTooltip;
+
+let styleTooptip = css`
+  position: fixed;
+  transform: translate(-50%, 0);
+  transform-origin: 50% calc(100% + 6px);
+  background-color: hsl(0, 0%, 0%);
+  color: white;
+  padding: 4px 6px;
+  border-radius: 3px;
+  font-size: 13px;
+  max-width: 320px;
+
+  white-space: normal;
+
+  :before {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    width: 20px;
+    height: 8px;
+    margin: auto;
+    content: "";
+    pointer-events: auto;
+    border-top: 8px solid black;
+    border-bottom: 0px solid transparent;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    box-sizing: border-box;
+  }
+`;
+
+let styleTooltipContainer = css`
+  z-index: 900;
+
+  .fade-in-out-enter {
+    opacity: 0.3;
+    transform: translate(-50%, 0) scale(0.94);
+  }
+  .fade-in-out-enter-active {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+    transition-property: opacity transform;
+    transition-duration: ${transitionDuration}ms;
+  }
+  .fade-in-out-exit {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+  .fade-in-out-exit-active {
+    opacity: 0.3;
+    transform: translate(-50%, 0) scale(0.94);
+    transition-property: opacity transform;
+    transition-duration: ${transitionDuration}ms;
+  }
+`;


### PR DESCRIPTION
Previews http://fe.jimu.io/jimo-basics/#/clamp-text

对于有省略文字的内容支持 tooltip 展示. 实现方案参考 http://jsfiddle.net/1hzhrwLs/ . 目前看效果基本可以.

目前 tooltip 的实现比较简单, 也没有检测边缘. 感觉后面需要单独搞, 或者直接接入第三方组件.

暂时提供了 `onTooltipStateChange` 接口用于获取状态, 但是也担心跟 antd DOM 结构的问题.