### PR TITLE
Add LabeledAttributes component; update tooltip styles and position; …

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -57,6 +57,12 @@ export let genRouter = {
     path: () => `/text-tooltip`,
     go: () => switchPath(`/text-tooltip`),
   },
+  labeledAttributes: {
+    name: "labeled-attributes",
+    raw: "labeled-attributes",
+    path: () => `/labeled-attributes`,
+    go: () => switchPath(`/labeled-attributes`),
+  },
   $: {
     name: "home",
     raw: "",
@@ -73,6 +79,7 @@ export type GenRouterTypeMain =
   | GenRouterTypeTree["loadingIndicator"]
   | GenRouterTypeTree["clampText"]
   | GenRouterTypeTree["textTooltip"]
+  | GenRouterTypeTree["labeledAttributes"]
   | GenRouterTypeTree["$"];
 
 export interface GenRouterTypeTree {
@@ -114,6 +121,12 @@ export interface GenRouterTypeTree {
   };
   textTooltip: {
     name: "text-tooltip";
+    params: {};
+    query: {};
+    next: null;
+  };
+  labeledAttributes: {
+    name: "labeled-attributes";
     params: {};
     query: {};
     next: null;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -8,5 +8,6 @@ export const routerRules: IRouteRule[] = [
   { path: "loading-indicator" },
   { path: "clamp-text" },
   { path: "text-tooltip" },
+  { path: "labeled-attributes" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -4,13 +4,14 @@ import { css, cx } from "emotion";
 import { HashRedirect, findRouteTarget } from "@jimengio/ruled-router/lib/dom";
 import { genRouter, GenRouterTypeMain } from "controller/generated-router";
 import { DocSidebar, ISidebarEntry } from "@jimengio/doc-frame";
-import { fullscreen, row } from "@jimengio/flex-styles";
+import { fullscreen, row, expand } from "@jimengio/flex-styles";
 import DemoButtons from "./demo/buttons";
 import DemoTodo from "./demo/todo";
 import DemoTabs from "./demo/tabs";
 import DemoLoadingIndicator from "./demo/loading-indicator";
 import DemoClampText from "./demo/clamp-text";
 import DemoTextTooltip from "./demo/text-tooltip";
+import DemoLabeledAttributes from "./demo/labeled-attributes";
 
 let items: ISidebarEntry[] = [
   {
@@ -37,6 +38,10 @@ let items: ISidebarEntry[] = [
     title: "Text tooltip",
     path: genRouter.textTooltip.name,
   },
+  {
+    title: "Labeled attributes",
+    path: genRouter.labeledAttributes.name,
+  },
 ];
 
 const renderChildPage = (routerTree: GenRouterTypeMain) => {
@@ -54,6 +59,8 @@ const renderChildPage = (routerTree: GenRouterTypeMain) => {
         return <DemoClampText />;
       case "text-tooltip":
         return <DemoTextTooltip />;
+      case "labeled-attributes":
+        return <DemoLabeledAttributes />;
       default:
         return <HashRedirect to={genRouter.buttons.name} noDelay></HashRedirect>;
     }
@@ -85,7 +92,7 @@ let Container: FC<{
         items={items}
       />
 
-      <div className={styleBody}>{renderChildPage(props.router)}</div>
+      <div className={cx(expand, styleBody)}>{renderChildPage(props.router)}</div>
     </div>
   );
 });

--- a/example/pages/demo/labeled-attributes.tsx
+++ b/example/pages/demo/labeled-attributes.tsx
@@ -1,0 +1,167 @@
+import React, { FC } from "react";
+import { css } from "emotion";
+import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
+import LabeledAttibutes, { ILabeledAttribute } from "../../../src/labeled-attributes";
+import { expand } from "@jimengio/flex-styles";
+
+let DemoLabeledAttributes: FC<{}> = React.memo((props) => {
+  /** Plugins */
+  /** Methods */
+  /** Effects */
+  /** Renderers */
+
+  let shortAttributes: ILabeledAttribute[] = [
+    {
+      label: "LWV-ULR-451",
+      value: "天水",
+    },
+    {
+      label: "Handan",
+      value: "Boertala",
+    },
+    {
+      label: "恩施",
+      value: "西双版纳",
+    },
+    {
+      label: "河池",
+      value: "Hangzhou",
+    },
+    {
+      label: "Shiyan",
+      value: "塔城",
+    },
+    {
+      label: "YMQ-MHF-521",
+      value: "博尔塔拉 伊犁 三亚",
+    },
+    {
+      label: "齐齐哈尔",
+      value: "Tongren",
+    },
+  ];
+
+  let longAttributes: ILabeledAttribute[] = [
+    {
+      label: "Liaocheng Lüliang Jingmen",
+      value: "重庆 Jieyang 伊春 哈密 海西 庆阳 Dingxi Tai'an Datong 韶关 Lincang 荆州",
+    },
+    {
+      label: "Enshi Yan'an Yongzhou",
+      value: "Nyingchi Changzhou Tieling",
+    },
+    {
+      label: "Tongchuan Chengdu Huaibei",
+      value: "Huangshan 资阳 Huainan 襄樊 Xinxiang 黄石 Dehong",
+    },
+    {
+      label: "Liaocheng Lüliang Jingmen",
+      value: "重庆 Jieyang 伊春 哈密 海西 庆阳 Dingxi Tai'an Datong 韶关 Lincang 荆州",
+    },
+    {
+      label: "Zhengzhou Hengyang",
+      value: "大同 锡林郭勒 Yichang Xuancheng Yancheng",
+    },
+    {
+      label: "48",
+      value:
+        "Linguolexi 重庆 河源 Taizhou Chamdo 池州 Kezilesukeerkezi 通化 文山 宣城 Ganzhou 阿勒泰 Xinyu Langfang 郑州 揭阳 Chifeng 威海 渭南 阿克苏 Huizhou Nanping Shangqiu 七台河 Puyang Xinyang Tongren Shantou Zhuhai Shanwei Chuzhou Xinyu Jiaozuo 十堰 Tai'an 吉林 唐山 Yushu Chuzhou Hainan Liaocheng Huainan 昌都 鄂州 赣州 Yiyang 伊春 Xinzhou Xiangfan",
+    },
+  ];
+
+  let mixedAttributes: ILabeledAttribute[] = [
+    {
+      label: "LWV-ULR-451",
+      value: "天水",
+    },
+    {
+      label: "Handan",
+      value: "Boertala",
+    },
+    {
+      label: "恩施",
+      value: "西双版纳",
+    },
+    {
+      label: "哈尔滨漳州陇南济宁",
+      value: "保定六盘水孝感宁波",
+    },
+    {
+      label: "湘潭",
+      value: "Dandong Hangzhou Quzhou",
+    },
+    {
+      label: "张掖铜陵宝鸡长沙",
+      value: "Dandong Hangzhou Quzhou",
+    },
+    {
+      label: "Daxinganling",
+      value: "宜昌 随州 益阳",
+    },
+    {
+      label: "Liaocheng Lüliang Jingmen",
+      value: "重庆 Jieyang 伊春 哈密 海西 庆阳 Dingxi Tai'an Datong 韶关 Lincang 荆州",
+    },
+    {
+      label: "48",
+      value:
+        "Linguolexi 重庆 河源 Taizhou Chamdo 池州 Kezilesukeerkezi 通化 文山 宣城 Ganzhou 阿勒泰 Xinyu Langfang 郑州 揭阳 Chifeng 威海 渭南 阿克苏 Huizhou Nanping Shangqiu 七台河 Puyang Xinyang Tongren Shantou Zhuhai Shanwei Chuzhou Xinyu Jiaozuo 十堰 Tai'an 吉林 唐山 Yushu Chuzhou Hainan Liaocheng Huainan 昌都 鄂州 赣州 Yiyang 伊春 Xinzhou Xiangfan",
+    },
+  ];
+
+  return (
+    <div className={expand}>
+      <DocDemo title="标签属性">
+        <DocBlock content={content} />
+        <DocSnippet code={code} />
+      </DocDemo>
+
+      <DocDemo title={"Short"} className={styleWidth}>
+        <LabeledAttibutes attributes={shortAttributes} />
+      </DocDemo>
+
+      <DocDemo title={"Short align right"} className={styleWidth}>
+        <LabeledAttibutes attributes={shortAttributes} alignToRight />
+      </DocDemo>
+
+      <DocDemo title={"Mixed"} className={styleWidth}>
+        <LabeledAttibutes attributes={mixedAttributes} />
+      </DocDemo>
+
+      <DocDemo title={"Mixed align right"} className={styleWidth}>
+        <LabeledAttibutes attributes={mixedAttributes} alignToRight />
+      </DocDemo>
+
+      <DocDemo title={"Long"} className={styleWidth}>
+        <LabeledAttibutes attributes={longAttributes} />
+      </DocDemo>
+    </div>
+  );
+});
+
+export default DemoLabeledAttributes;
+
+let styleWidth = css`
+  /* max-width: 1000px; */
+  max-width: 10000px;
+  min-width: 0;
+  width: auto;
+`;
+
+let code = `
+let shortAttributes: ILabeledAttribute[] = [
+  {
+    label: "LWV-ULR-451",
+    value: "天水",
+  },
+  // ...
+]
+
+<LabeledAttibutes attributes={shortAttributes} />
+
+<LabeledAttibutes attributes={shortAttributes} alignToRight />
+`;
+
+let content = `
+LabeledAttibutes 默认提供三列的布局. 支持标签左右对齐. 具体业务还可以根据 \`itemClassName\`, \`LabelClassName\`, \`itemWidth\` 等属性控制.
+`;

--- a/example/pages/demo/text-tooltip.tsx
+++ b/example/pages/demo/text-tooltip.tsx
@@ -54,6 +54,15 @@ let DemoTextTooltip: FC<{}> = React.memo((props) => {
         <Space height={40} />
       </DocDemo>
 
+      <DocDemo title="对于包含节点样式的组件的 text 展示">
+        <DocBlock content={contentDelay} />
+        <DocSnippet code={codeDelay} />
+        <div className={styleNarrow}>
+          <ClampText text={<a href="#">{text}</a>} tooltipText={text} addTooltip />
+        </div>
+        <Space height={40} />
+      </DocDemo>
+
       <DocDemo title="Parent state">
         <DocBlock content={contentTooltipState} />
         <DocSnippet code={codeTooltipState} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-basics",
-  "version": "0.0.14-a2",
+  "version": "0.0.15-a1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -6,6 +6,8 @@ export interface IClampTextProps {
   /** defaults to 1 */
   lines?: number;
   text: React.ReactNode;
+  /** text property might be a node with text, use tooltipText to overwrite */
+  tooltipText?: string;
   className?: string;
   style?: CSSProperties;
   tooltipClassName?: string;
@@ -23,7 +25,7 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
   let leavingTimeoutRef = useRef<NodeJS.Timeout>(null);
 
   let [showToopTip, setShowTooltip] = useState(false);
-  let [pointer, setPointer] = useState({ x: 0, y: 0 });
+  let [pointer, setPointer] = useState({ x: 0, top: 0, bottom: 0 });
 
   let lines = props.lines || 1;
   let delay = props.delay ?? 160;
@@ -42,7 +44,8 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
       setShowTooltip(truncated);
       setPointer({
         x: rect.left + el.offsetWidth / 2,
-        y: rect.top,
+        top: rect.top,
+        bottom: rect.bottom,
       });
 
       if (props.onTooltipStateChange != null) {
@@ -87,7 +90,7 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
   };
 
   let onTextClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (event.target === elRef.current) {
+    if (props.onTextClick != null && event.target === elRef.current) {
       props.onTextClick(event);
     }
   };
@@ -99,7 +102,7 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
     if (!props.addTooltip) {
       return null;
     }
-    return <BasicTooltip pointer={pointer} visible={showToopTip} className={props.tooltipClassName} text={props.text} />;
+    return <BasicTooltip pointer={pointer} visible={showToopTip} className={props.tooltipClassName} text={props.tooltipText || props.text} />;
   };
 
   if (lines === 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { default as TodoFeature } from "./todo-feature";
 export { default as LoadingIndicator } from "./loading-indicator";
 export { default as LoadingArea } from "./loading-area";
 export { default as ClampText, IClampTextProps } from "./clamp-text";
+export { default as LabeledAttributes, ILabeledAttribute } from "./labeled-attributes";

--- a/src/labeled-attributes.tsx
+++ b/src/labeled-attributes.tsx
@@ -1,0 +1,78 @@
+import React, { FC, ReactNode } from "react";
+import { css, cx } from "emotion";
+import { row, expand } from "@jimengio/flex-styles";
+
+export interface ILabeledAttribute {
+  label: string;
+  value: ReactNode;
+  itemClassName?: string;
+  labelClassName?: string;
+  valueClassName?: string;
+  itemWidth?: number | string;
+  labelWidth?: number | string;
+}
+
+let LabeledAttibutes: FC<{
+  attributes: ILabeledAttribute[];
+  className?: string;
+  alignToRight?: boolean;
+  itemClassName?: string;
+  /** 默认 320px/33%, 具体按照业务配置 */
+  itemWidth?: string | number;
+  labelClassName?: string;
+  labelWidth?: string | number;
+
+  emptySymbol?: string;
+}> = React.memo((props) => {
+  /** Plugins */
+  /** Methods */
+  /** Effects */
+  /** Renderers */
+
+  return (
+    <div className={cx(styleContainer, props.className)}>
+      {props.attributes.map((attr, idx) => {
+        return (
+          <div key={idx} className={cx(row, styleItem, props.itemClassName, attr.itemClassName)} style={{ width: attr.itemWidth || props.itemWidth }}>
+            <div
+              className={cx(styleLabel, props.alignToRight ? styleAlignToRight : null, props.labelClassName, attr.labelClassName)}
+              style={{ width: attr.labelWidth || props.labelWidth }}
+            >
+              {attr.label}:
+            </div>
+            <div className={cx(expand, styleValue)}>{attr.value != null && attr.value !== "" ? attr.value : props.emptySymbol ?? "-"}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+export default LabeledAttibutes;
+
+let styleItem = css`
+  padding-right: 16px;
+  margin: 4px 0;
+  display: inline-flex;
+  min-width: 320px;
+  min-width: max(320px, 33%);
+  vertical-align: top;
+  font-size: 14px;
+  line-height: 22px;
+`;
+
+let styleLabel = css`
+  color: hsla(0, 0%, 44%, 1);
+  margin-right: 12px;
+`;
+
+let styleValue = css`
+  color: hsla(0, 0%, 20%, 1);
+`;
+
+let styleContainer = css``;
+
+let styleAlignToRight = css`
+  text-align: right;
+  min-width: 120px;
+`;

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -4,11 +4,11 @@ import { css, cx } from "emotion";
 import { CSSTransition } from "react-transition-group";
 
 let transitionDuration = 120;
-let tipColor = "rgb(239,239,239)";
+let tipColor = "hsla(0, 0%, 59%, 1)";
 
 let BasicTooltip: FC<{
   visible: boolean;
-  pointer: { x: number; y: number };
+  pointer: { x: number; top: number; bottom: number };
   text: React.ReactNode;
   className?: string;
 }> = React.memo((props) => {
@@ -31,15 +31,25 @@ let BasicTooltip: FC<{
     };
   }, []);
 
+  let isLongText = typeof props.text === "string" && props.text.length > 100;
+  let showBelow = props.pointer.top < 240;
+
   /** Renderers */
   return ReactDOM.createPortal(
     <CSSTransition in={props.visible} timeout={transitionDuration} classNames="fade-in-out" unmountOnExit>
       <div
-        className={cx(styleTooptip, props.className)}
-        style={{
-          left: props.pointer.x,
-          bottom: window.innerHeight - props.pointer.y + 6,
-        }}
+        className={cx(styleTooptip, isLongText ? styleLongText : null, showBelow ? styleBelow : null, props.className)}
+        style={
+          showBelow
+            ? {
+                left: props.pointer.x,
+                top: props.pointer.bottom + 6,
+              }
+            : {
+                left: props.pointer.x,
+                bottom: window.innerHeight - props.pointer.top + 6,
+              }
+        }
       >
         {props.text}
       </div>
@@ -58,7 +68,7 @@ let styleTooptip = css`
   transition-property: opacity, transform;
   transform-origin: 50% calc(100% + 6px);
   background-color: ${tipColor};
-  color: #323232;
+  color: white;
   padding: 5px 8px;
   border-radius: 2px;
   font-size: 13px;
@@ -120,5 +130,40 @@ let styleTooltipContainer = css`
     opacity: 0.3;
     transform: translate(-50%, 0) scale(0.94);
     transition-duration: ${transitionDuration}ms;
+  }
+`;
+
+let styleLongText = css`
+  max-width: 480px;
+`;
+
+let styleBelow = css`
+  :before {
+    position: absolute;
+    bottom: 100%;
+    right: 0;
+    top: 0;
+    left: 0;
+    display: block;
+    width: 20px;
+    height: 8px;
+    margin: auto;
+    content: "";
+    pointer-events: auto;
+    border-bottom: 8px solid ${tipColor};
+    border-top: 0px solid transparent;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    box-sizing: border-box;
+  }
+
+  :after {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    height: 8px;
+    width: 100%;
+    content: "";
+    background-color: transparent;
   }
 `;

--- a/src/underline-tabs.tsx
+++ b/src/underline-tabs.tsx
@@ -43,6 +43,7 @@ let styleUnderlineTabs = css`
 `;
 
 let styleUnderlineTab = css`
+  font-size: 14px;
   color: hsla(0, 0%, 59%, 1);
   border-bottom: 2px solid white;
   cursor: pointer;
@@ -50,6 +51,8 @@ let styleUnderlineTab = css`
   transition-duration: 240ms;
   line-height: 28px;
   padding: 0 12px;
+  min-width: 56px;
+  text-align: center;
 
   :hover {
     background-color: hsla(0, 0%, 98%, 1);


### PR DESCRIPTION
新增组件 `LabeledAttributes` 提供常用的标签布局. 一般为三列, 具体有样式需要业务再参数控制了, 预览 http://fe.jimu.io/jimo-basics/#/labeled-attributes

![image](https://user-images.githubusercontent.com/25790987/76742462-15713d00-67ac-11ea-834d-9c8eeabf17af.png)

Tooltip 样式调整, 以及支持在一定区域向下弹出(写死的 y 值, 不够准确). 主要目的是减少顶部超出屏幕的情况.

![image](https://user-images.githubusercontent.com/25790987/76742485-1e620e80-67ac-11ea-9ce9-51268a6b31fc.png)

Tabs 样式微调.
