### PR TITLE
reuse code of useTooltip in ClampText

### DIFF
--- a/example/pages/demo/clamp-text.tsx
+++ b/example/pages/demo/clamp-text.tsx
@@ -38,6 +38,14 @@ let DemoClampText: FC<{}> = React.memo((props) => {
           <ClampText lines={4} text={text} />
         </div>
       </DocDemo>
+
+      <DocDemo title={"Empty text"}>
+        <DocBlock content={empty} />
+        <DocSnippet code={emptyCode} />
+        <div>
+          <ClampText text={""} />
+        </div>
+      </DocDemo>
     </div>
   );
 });
@@ -62,3 +70,11 @@ let codeInline = `<ClampText text={text} />`;
 let code2Lines = `<ClampText lines={2} text={text} />`;
 
 let code4Lines = `<ClampText lines={4} text={text} />`;
+
+let empty = `
+\`text\` 传入空字符串时默认会显示 \`-\`. 默认的符号可以通过 \`emptySymbol\` 改写.
+`;
+
+let emptyCode = `
+<ClampText text={""} />
+`;

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -17,6 +17,8 @@ export interface IClampTextProps {
   delay?: number;
   /** respond to clicks on text, not including tooltop */
   onTextClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  /** defaults to `-` */
+  emptySymbol?: string;
 }
 
 let ClampText: FC<IClampTextProps> = React.memo((props) => {
@@ -52,10 +54,12 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
     return tooltipPlugin.ui;
   };
 
+  let emptySymbol = props.emptySymbol ?? "-";
+
   if (lines === 1) {
     return (
       <div className={cx(styleSingleLine, props.className)} style={props.style} ref={tooltipPlugin.ref} onClick={onTextClick}>
-        {props.text}
+        {props.text || emptySymbol}
         {renderTooltip()}
       </div>
     );

--- a/src/clamp-text.tsx
+++ b/src/clamp-text.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState, useRef, CSSProperties, useReducer } from "react";
 import { css, cx } from "emotion";
-import BasicTooltip from "./tooltip";
+import BasicTooltip, { useTooltip } from "./tooltip";
 
 export interface IClampTextProps {
   /** defaults to 1 */
@@ -20,77 +20,24 @@ export interface IClampTextProps {
 }
 
 let ClampText: FC<IClampTextProps> = React.memo((props) => {
-  let elRef = useRef<HTMLDivElement>();
-  let enteringTimeoutRef = useRef<NodeJS.Timeout>(null);
-  let leavingTimeoutRef = useRef<NodeJS.Timeout>(null);
-
-  let [showToopTip, setShowTooltip] = useState(false);
-  let [pointer, setPointer] = useState({ x: 0, top: 0, bottom: 0 });
-
   let lines = props.lines || 1;
-  let delay = props.delay ?? 160;
 
   /** Plugins */
+
+  let tooltipPlugin = useTooltip({
+    text: props.tooltipText || props.text,
+    tooltipClassName: props.tooltipClassName,
+    delay: props.delay,
+    shouldPop: (element) => {
+      return element.offsetHeight < element.scrollHeight || element.offsetWidth < element.scrollWidth;
+    },
+    onStatusChange: props.onTooltipStateChange,
+  });
+
   /** Methods */
 
-  let detectTruncated = () => {
-    let el = elRef.current;
-
-    let truncated = el.offsetHeight < el.scrollHeight || el.offsetWidth < el.scrollWidth;
-
-    if (props.addTooltip || props.onTooltipStateChange != null) {
-      let rect = el.getBoundingClientRect() as DOMRect;
-
-      setShowTooltip(truncated);
-      setPointer({
-        x: rect.left + el.offsetWidth / 2,
-        top: rect.top,
-        bottom: rect.bottom,
-      });
-
-      if (props.onTooltipStateChange != null) {
-        props.onTooltipStateChange(truncated);
-      }
-    }
-  };
-
-  let handleEnter = () => {
-    if (enteringTimeoutRef.current != null) {
-      return;
-    }
-
-    if (leavingTimeoutRef.current != null) {
-      clearTimeout(leavingTimeoutRef.current);
-      leavingTimeoutRef.current = null;
-    }
-
-    enteringTimeoutRef.current = setTimeout(() => {
-      detectTruncated();
-      enteringTimeoutRef.current = null;
-    }, delay);
-  };
-
-  let handleLeave = () => {
-    if (leavingTimeoutRef.current != null) {
-      return;
-    }
-
-    if (enteringTimeoutRef.current != null) {
-      clearTimeout(enteringTimeoutRef.current);
-      enteringTimeoutRef.current = null;
-    }
-
-    leavingTimeoutRef.current = setTimeout(() => {
-      setShowTooltip(false);
-      if (props.onTooltipStateChange != null && showToopTip) {
-        props.onTooltipStateChange(false);
-      }
-      leavingTimeoutRef.current = null;
-    }, delay);
-  };
-
   let onTextClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    if (props.onTextClick != null && event.target === elRef.current) {
+    if (props.onTextClick != null && event.target === tooltipPlugin.ref.current) {
       props.onTextClick(event);
     }
   };
@@ -102,23 +49,12 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
     if (!props.addTooltip) {
       return null;
     }
-    return <BasicTooltip pointer={pointer} visible={showToopTip} className={props.tooltipClassName} text={props.tooltipText || props.text} />;
+    return tooltipPlugin.ui;
   };
 
   if (lines === 1) {
     return (
-      <div
-        className={cx(styleSingleLine, props.className)}
-        style={props.style}
-        ref={elRef}
-        onMouseEnter={() => {
-          handleEnter();
-        }}
-        onMouseLeave={() => {
-          handleLeave();
-        }}
-        onClick={onTextClick}
-      >
+      <div className={cx(styleSingleLine, props.className)} style={props.style} ref={tooltipPlugin.ref} onClick={onTextClick}>
         {props.text}
         {renderTooltip()}
       </div>
@@ -128,16 +64,10 @@ let ClampText: FC<IClampTextProps> = React.memo((props) => {
   return (
     <div
       className={styleClampText}
-      ref={elRef}
+      ref={tooltipPlugin.ref}
       style={{
         WebkitLineClamp: lines,
         ...props.style,
-      }}
-      onMouseEnter={() => {
-        handleEnter();
-      }}
-      onMouseLeave={() => {
-        handleLeave();
       }}
       onClick={onTextClick}
     >

--- a/src/tooltip.tsx
+++ b/src/tooltip.tsx
@@ -68,6 +68,9 @@ export interface ITooltipWrapperProps {
   delay?: number;
   /** respond to clicks on text, not including tooltop */
   onTextClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  /** detect if popup is really required */
+  shouldPop?: (element: HTMLElement) => boolean;
+  onStatusChange?: (visible: boolean) => void;
 }
 
 export let useTooltip = (props: ITooltipWrapperProps) => {
@@ -85,6 +88,11 @@ export let useTooltip = (props: ITooltipWrapperProps) => {
   /** Methods */
 
   let handleEnter = () => {
+    if (props.shouldPop != null) {
+      if (!props.shouldPop(elRef.current)) {
+        return;
+      }
+    }
     if (enteringTimeoutRef.current != null) {
       return;
     }
@@ -152,6 +160,10 @@ export let useTooltip = (props: ITooltipWrapperProps) => {
       window.removeEventListener("wheel", onWheel);
     };
   });
+
+  useEffect(() => {
+    props.onStatusChange?.(showToopTip);
+  }, [showToopTip]);
 
   /** Renderers */
 


### PR DESCRIPTION
`useTooltip` 最初的代码是从 ClampText 当中剥离出来的. 导致存在两份逻辑, 现在完成了抽象和复用.
