### PR TITLE
add data hooks on clickable items

### DIFF
--- a/example/pages/demo/buttons.tsx
+++ b/example/pages/demo/buttons.tsx
@@ -33,7 +33,7 @@ let DemoButtons: FC<{}> = React.memo((props) => {
       <DocDemo title={"Basic button"} link={getLink("buttons.tsx")} className={styleDemo}>
         <DocSnippet code={codeButton} />
         <div>
-          <JimoButton text={"DEMO"} onClick={null} />
+          <JimoButton text={"DEMO"} onClick={null} data-action="demo action" />
           <Space width={8} />
           <JimoButton text={"DEMO"} onClick={() => {}} disabled />
         </div>
@@ -77,6 +77,7 @@ let DemoButtons: FC<{}> = React.memo((props) => {
           <Space width={8} />
           <JimoLink
             text="Confirm"
+            data-action="confirm demo"
             onClick={() => {
               console.log("Clicked");
             }}

--- a/src/jimo-button.tsx
+++ b/src/jimo-button.tsx
@@ -14,6 +14,8 @@ let JimoButton: FC<{
   canceling?: boolean;
   disabled?: boolean;
   onClick: (event: React.MouseEvent<any, MouseEvent>) => void;
+  /** data attribute hook passing to data-action */
+  "data-action"?: string;
 }> = React.memo((props) => {
   /** Methods */
   /** Effects */
@@ -22,7 +24,7 @@ let JimoButton: FC<{
   let bordered = !props.fillColor && !props.canceling && !props.disabled;
 
   return (
-    <div
+    <button
       className={cx(
         rowCenter,
         styleButton,
@@ -32,6 +34,7 @@ let JimoButton: FC<{
         bordered ? styleBordered : null,
         props.disabled ? styleDisabled : null
       )}
+      data-action={props["data-action"] || props.text}
       onClick={(event) => {
         if (props.disabled) {
           return;
@@ -47,7 +50,7 @@ let JimoButton: FC<{
         </>
       ) : null}
       {props.text}
-    </div>
+    </button>
   );
 });
 
@@ -66,6 +69,13 @@ const styleButton = css`
   transition-duration: 240ms;
   user-select: none;
   font-size: 14px;
+  background-color: white;
+  border: none;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 `;
 
 let styleFilled = css`

--- a/src/jimo-tabs.tsx
+++ b/src/jimo-tabs.tsx
@@ -8,6 +8,7 @@ export interface IJimoTabItem {
   key?: string;
   value: string;
   title: string;
+  "data-entry"?: string;
 }
 
 /** 自定义 Tabs 组件, 选中时整个背景改变颜色 */
@@ -27,6 +28,7 @@ let JimoTabs: FC<{
           <div
             key={item.key || item.title}
             onClick={() => props.onClick(item)}
+            data-entry={item["data-entry"] || item.key || item.title}
             className={cx(
               styleTab,
               props.value === item.value ? styleSelected : null,


### PR DESCRIPTION
当前包含:

* `data-action` 按钮/链接点击行为.
* `data-entry` Tab 元素.
